### PR TITLE
Pathogenic Isolator

### DIFF
--- a/nano/templates/pathogenic_isolator.tmpl
+++ b/nano/templates/pathogenic_isolator.tmpl
@@ -81,7 +81,7 @@
       {{if data.database}}
         {{for data.database}}
           <div class='itemContent'>
-            <div class='highlight fixedLeft'>{{:data.name}}</div>
+            <div class='highlight fixedLeft'>{{:value.name}}</div>
             {{:helper.link('Details', 'circle-arrow-s', { 'entry' : 1, 'view' : value.record }, null, 'fixedLeft')}}
           </div>
         {{/for}}


### PR DESCRIPTION
Fixes the Isolator saying "unidentified" for every entry on the List screen.